### PR TITLE
Update prod env, add deploy script

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
-GRAPHQL_URL=https://prod.kartat.hsl.fi/jore/graphql
-LINK_URL=https://prod.kartat.hsl.fi
+GRAPHQL_URL=https://kartat.hsl.fi/jore/graphql
+LINK_URL=https://kartat.hsl.fi
 PORT=3000

--- a/docker-deploy-tag.sh
+++ b/docker-deploy-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+ORG=${ORG:-hsldevcom}
+
+read -p "Tag: " TAG
+
+DOCKER_TAG=${TAG:-production}
+DOCKER_IMAGE=$ORG/hsl-map-generator-ui:${DOCKER_TAG}
+
+docker build --build-arg BUILD_ENV=${TAG:-production} -t $DOCKER_IMAGE .
+docker push $DOCKER_IMAGE


### PR DESCRIPTION
- Update the prod env url to point to current prod (kartat.hsl.fi). The old prod.kartat.hsl is a remnant from migration period when we had the old and new production running in side-by-side.
- Add bash script that builds and pushes a docker image tagged by user prompt.